### PR TITLE
Adding support for the WINS entry type

### DIFF
--- a/dnstool.py
+++ b/dnstool.py
@@ -309,7 +309,8 @@ RECORD_TYPE_MAPPING = {
     2: 'NS',
     5: 'CNAME',
     6: 'SOA',
-    33: 'SRV'
+    33: 'SRV',
+    65281: 'WINS'
 }
 
 def main():


### PR DESCRIPTION
Nothing fancy, I just added one line that matches the entry type 65281 with WINS.
Since ADIDNS wildcard poisoning only works when WINS is not enabled [more info](https://www.thehacker.recipes/ad/movement/mitm-and-coerced-authentications/adidns-spoofing), I figured it could be nice to be able to enumerate its state. This can now be done with the following command:
```sh
$ dnstool.py -u 'domain\user1' -p complexpassword --record '@' 192.168.56.101

[-] Connecting to host...
[-] Binding to host
[+] Bind OK
[+] Found record @
DC=@,DC=domain.local,CN=MicrosoftDNS,DC=DomainDnsZones,DC=domain,DC=local
[+] Record entry:
 - Type: 65281 (WINS) (Serial: 350)
DC=@,DC=domain.local,CN=MicrosoftDNS,DC=DomainDnsZones,DC=domain,DC=local
[...]
```
Before this PR, type was just printed as "Unsupported".
