### PR TITLE
Add random number to unknown username to obtain multiple certificates

### DIFF
--- a/lib/utils/kerberos.py
+++ b/lib/utils/kerberos.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import struct
 import datetime
+import random
 from binascii import unhexlify, hexlify
 from pyasn1.type.univ import noValue
 from pyasn1.codec.der import decoder, encoder
@@ -43,7 +44,7 @@ def get_auth_data(token, options):
     if options.victim:
         username = options.victim
     else:
-        username = "unknown$"
+        username = f"unknown{random.randint(0, 10000):04d}$"
     return {
         "domain": domain,
         "username": username,


### PR DESCRIPTION
When conducting a Kerberos relaying attack, it is usually possible to capture tickets from multiple machines in the local network segment. In this case, it does not make sense to specify a victim and therefore, the username is set to `unknown$`. However, the target processor then thinks it is always the same user and will not request a new certificate.

With this PR, a random number is appended to the "unknown" username (e.g. `unknown2395$`), such that the attack can be conducted against multiple machines.