### PR TITLE
Fix nthash and lmhash computation

### DIFF
--- a/dnstool.py
+++ b/dnstool.py
@@ -388,7 +388,7 @@ def main():
         TGS = None
         try:
             # Hashes
-            lmhash, nthash = password.split(':')
+            lmhash, nthash = args.password.split(':')
             assert len(nthash) == 32
             password = ''
         except:


### PR DESCRIPTION
The `password` local variable has to be taken from `args`, otherwise it is undefined.
In the try-catch block, the `password` variable was not defined, therefore the except block was always taken, erasing `lmhash` and `nthash`.

The bug occures when expecting `dnstool.py` to retrieve a TGT from the NT and LM hashes:
```
python3 dnstool.py -u 'MYDOMAIN.LOCAL\myuser' -p '<lmhash>:<nthash>' --print-zones -k -dc-ip 10.0.0.1 DC01.mydomain.local
```
If we print the error inside the except, we get:
```
cannot access local variable 'password' where it is not associated with a value
```