### PR TITLE
Modify log option to display output by default

### DIFF
--- a/lib/servers/smbrelayserver.py
+++ b/lib/servers/smbrelayserver.py
@@ -63,7 +63,7 @@ class SMBRelayServer(Thread):
         smbConfig.set('global','server_name','server_name')
         smbConfig.set('global','server_os','UNIX')
         smbConfig.set('global','server_domain','WORKGROUP')
-        smbConfig.set('global','log_file','smb.log')
+        smbConfig.set('global','log_file','None')
         smbConfig.set('global','credentials_file','')
 
         if self.config.smb2support is True:


### PR DESCRIPTION
When using the SMB relay server nothing is displayed on STDOUT by default, this is due to a logging file beeing used by default, this is disabled on the upstream SMB relay server of fortra cf https://github.com/fortra/impacket/blob/835e17550b57606ee3c681ae1c3f0edea096ec19/impacket/examples/ntlmrelayx/servers/smbrelayserver.py#L81 

This PR fix this :)