### PR TITLE
Add support for Subject Alternative Name

### DIFF
--- a/krbrelayx.py
+++ b/krbrelayx.py
@@ -82,6 +82,8 @@ def main():
             c.setWpadOptions(options.wpad_host, options.wpad_auth_num)
             c.setSMB2Support(not options.no_smb2support)
             c.setInterfaceIp(options.interface_ip)
+            if options.altname:
+                c.setAltName(options.altname)
             if options.krbhexpass and not options.krbpass:
                 c.setAuthOptions(options.aesKey, options.hashes, options.dc_ip, binascii.unhexlify(options.krbhexpass), options.krbsalt, True)
             else:
@@ -181,6 +183,7 @@ def main():
     adcsoptions = parser.add_argument_group("AD CS attack options")
     adcsoptions.add_argument('--adcs', action='store_true', required=False, help='Enable AD CS relay attack')
     adcsoptions.add_argument('--template', action='store', metavar="TEMPLATE", required=False, help='AD CS template. Defaults to Machine or User whether relayed account name ends with `$`. Relaying a DC should require specifying `DomainController`')
+    adcsoptions.add_argument('--altname', action='store', metavar="ALTNAME", required=False, help='Subject Alternative Name to use when performing ESC1 or ESC6 attacks.')
     adcsoptions.add_argument('-v', "--victim", action='store', metavar = 'TARGET', help='Victim username or computername$, to request the correct certificate name.')
 
     try:


### PR DESCRIPTION
This is already a feature in [ntlmrelayx](https://github.com/fortra/impacket/blob/master/examples/ntlmrelayx.py#L217), so the option just needs to be exposed.