### PR TITLE
Fix small error when using Kerberos to add SPN

### DIFF
--- a/addspn.py
+++ b/addspn.py
@@ -108,7 +108,7 @@ def main():
         if args.dc_ip is None:
             kdcHost = domain
         else:
-            kdcHost = options.dc_ip
+            kdcHost = args.dc_ip
         userName = Principal(user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
         if not TGT and not TGS:
             tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash, args.aesKey, kdcHost)


### PR DESCRIPTION
Fixed a small error where the dc_ip for kdcHost could not be found. This can be relevant in multi-domain environments where we have to be able to supply the IP address for the selected DC via arguments.