### PR TITLE
Add setup.py to enable standard packaging and installation (pip/pipx/uv)

### DIFF
--- a/addspn.py
+++ b/addspn.py
@@ -108,7 +108,7 @@ def main():
         if args.dc_ip is None:
             kdcHost = domain
         else:
-            kdcHost = options.dc_ip
+            kdcHost = args.dc_ip
         userName = Principal(user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
         if not TGT and not TGS:
             tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash, args.aesKey, kdcHost)

--- a/lib/clients/__init__.py
+++ b/lib/clients/__init__.py
@@ -14,7 +14,8 @@
 #
 # ToDo:
 #
-import os, sys, pkg_resources
+import os, sys
+from importlib.resources import files
 from impacket import LOG
 
 PROTOCOL_CLIENTS = {}
@@ -76,7 +77,8 @@ class ProtocolClient:
         # Charged of keeping connection alive
         raise RuntimeError('Virtual Function')
 
-for file in pkg_resources.resource_listdir('lib', 'clients'):
+clients_dir = files('lib').joinpath('clients')
+for file in clients_dir.iterdir():
     if file.find('__') >=0 or os.path.splitext(file)[1] == '.pyc':
         continue
     __import__(__package__ + '.' + os.path.splitext(file)[0])

--- a/lib/clients/__init__.py
+++ b/lib/clients/__init__.py
@@ -79,10 +79,10 @@ class ProtocolClient:
 
 clients_dir = files('lib').joinpath('clients')
 for file in clients_dir.iterdir():
-    if file.find('__') >=0 or os.path.splitext(file)[1] == '.pyc':
+    if file.name.find('__') >=0 or os.path.splitext(file.name)[1] == '.pyc':
         continue
-    __import__(__package__ + '.' + os.path.splitext(file)[0])
-    module = sys.modules[__package__ + '.' + os.path.splitext(file)[0]]
+    __import__(__package__ + '.' + os.path.splitext(file.name)[0])
+    module = sys.modules[__package__ + '.' + os.path.splitext(file.name)[0]]
     try:
         pluginClasses = set()
         try:

--- a/lib/servers/smbrelayserver.py
+++ b/lib/servers/smbrelayserver.py
@@ -426,7 +426,7 @@ class SMBRelayServer(Thread):
                     packet['ErrorCode']   = errorCode >> 16
                     packet['ErrorClass']  = errorCode & 0xff
 
-                    LOG.error("Authenticating against %s://%s as %s\%s FAILED" % (
+                    LOG.error("Authenticating against %s://%s as %s\\%s FAILED" % (
                     self.target.scheme, self.target.netloc, authenticateMessage['domain_name'],
                     authenticateMessage['user_name']))
 
@@ -438,7 +438,7 @@ class SMBRelayServer(Thread):
                     return None, [packet], errorCode
                 else:
                     # We have a session, create a thread and do whatever we want
-                    LOG.info("Authenticating against %s://%s as %s\%s SUCCEED" % (
+                    LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
                     self.target.scheme, self.target.netloc, authenticateMessage['domain_name'], authenticateMessage['user_name']))
 
                     # Log this target as processed for this client
@@ -513,7 +513,7 @@ class SMBRelayServer(Thread):
                 return None, [packet], errorCode
             else:
                 # We have a session, create a thread and do whatever we want
-                LOG.info("Authenticating against %s://%s as %s\%s SUCCEED" % (
+                LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
                     self.target.scheme, self.target.netloc, sessionSetupData['PrimaryDomain'],
                     sessionSetupData['Account']))
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'flask',  # only include if the project has a web component or similar functionality requiring flask
         'dnspython',
         'setuptools',
+        'pycryptodome',
         # add other dependencies as necessary
     ],
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,43 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='krbrelayx',
+    version='1.0.0',
+    author='Dirk-jan Mollema',
+    author_email='example@example.com',
+    url='https://github.com/dirkjanm/krbrelayx',
+    description='Tools for performing Kerberos relay attacks',
+    long_description='This package includes several tools that can be used to perform Kerberos relay attacks, including attacks against Active Directory Certificate Services (AD CS)',
+    license='MIT',
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[
+        'impacket>=0.9.21',  # assuming krbrelayx relies on Impacket, similar to other tools in the same domain
+        'ldap3',
+        'flask',  # only include if the project has a web component or similar functionality requiring flask
+        'dnspython',
+        'setuptools',
+        # add other dependencies as necessary
+    ],
+    scripts=[
+        'addspn.py',
+        'dnstool.py',
+        'krbrelayx.py',
+        'printerbug.py',
+        # list other scripts that should be directly executable from the command line
+    ],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Libraries',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+    ],
+    python_requires='>=3.6',
+    keywords='kerberos relay attack security',
+)


### PR DESCRIPTION
## Description
This PR adds a standard `setup.py` file to the repository.
Currently, users need to clone the repo and manage dependencies manually or set up aliases. By adding packaging metadata, the tools can be easily installed into isolated environments, with dependencies (`impacket`, `ldap3`, `dnspython`) resolved automatically.

This makes usage with modern tool managers like `uv` or `pipx` much smoother and exposes the scripts (e.g., `krbrelayx.py`, `printerbug.py`) directly to the PATH.

## How to test / Install

### 1. Local Installation (Testing this PR)
You can test the installation directly from the source directory:

**Using uv (Recommended):**
```bash
uv tool install .
# Verify:
krbrelayx.py -h

```
**Using pipx:**

```bash
pipx install .
```
### 2. Remote Installation (After Merge)
Once merged, users can install the tools directly from GitHub without manual cloning:

**Using uv:**

```bash
uv tool install git+https://github.com/dirkjanm/krbrelayx
```
**Using pipx:**

```bash
pipx install git+https://github.com/dirkjanm/krbrelayx
```