### PR TITLE
fix: load dc-ip from args

### DIFF
--- a/addspn.py
+++ b/addspn.py
@@ -108,7 +108,7 @@ def main():
         if args.dc_ip is None:
             kdcHost = domain
         else:
-            kdcHost = options.dc_ip
+            kdcHost = args.dc_ip
         userName = Principal(user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
         if not TGT and not TGS:
             tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash, args.aesKey, kdcHost)


### PR DESCRIPTION
Simple fix to solve

```shell
addspn -u 'pirate.htb\a.white_adm' -p 'toto' -k -s 'http/WEB01.pirate.htb' -t 'DC01.PIRATE.HTB' -dc-ip 10.129.13.233 dc01.pirate.htb --additional

Traceback (most recent call last):
  File "/usr/share/krbrelayx/addspn.py", line 211, in <module>
    main()
    ~~~~^^
  File "/usr/share/krbrelayx/addspn.py", line 111, in main
    kdcHost = options.dc_ip
              ^^^^^^^
NameError: name 'options' is not defined
```
Not sure where `options` live, but not in the code, for sure ;-)